### PR TITLE
Rename form field prop `name` to `id`

### DIFF
--- a/src/components/FormField.svelte
+++ b/src/components/FormField.svelte
@@ -9,30 +9,34 @@
 
   export let title: string
   export let note = ``
-  export let name: keyof SignupStore
+  export let id: keyof SignupStore
   export let placeholder = title
   export let options: string[] = []
   export let type: FormFieldType = `text`
   export let required = false
-  export let min: number | undefined = undefined
-  export let max: number | undefined = undefined
+  export let min: number | null = null
+  export let max: number | null = null
   export let maxSelect: number | null = null
 
   let input: HTMLInputElement
+  let label: HTMLLabelElement
   let slider: HTMLDivElement
 
-  let value: string | number | string[] | boolean | undefined
+  let value: string | number | boolean | (string | number)[] | undefined
 
-  $: $signupStore[name] = { required, node: label }
-  $: $signupStore[name].value = value
-  $: $signupStore[name].node = label
-  $: if (value) $signupStore[name].error = ``
-
-  let label: HTMLLabelElement
+  $: $signupStore[id] = { required, node: label }
+  $: $signupStore[id].value = value
+  $: $signupStore[id].node = label
+  $: if (value) $signupStore[id].error = ``
 </script>
 
 <!-- on:click|preventDefault to avoid changing Toggle state and opening MultiSelects on clicking their labels -->
-<label for={name} class:required bind:this={label}>
+<label
+  for={id}
+  class:required
+  bind:this={label}
+  on:click={(e) => type === `toggle` && e.preventDefault()}
+>
   {@html title}
 </label>
 
@@ -40,14 +44,13 @@
   {@html note}
 {/if}
 
-{#if $signupStore[name]?.error}
-  <small class="error">{$signupStore[name].error}</small>
+{#if $signupStore[id]?.error}
+  <small class="error">{$signupStore[id].error}</small>
 {/if}
 
 {#if type === `select`}
   <MultiSelect
-    id={name}
-    {name}
+    {id}
     {placeholder}
     {options}
     {maxSelect}
@@ -62,9 +65,9 @@
     --sms-selected-text-color="white"
   />
 {:else if type === `toggle`}
-  <Toggle {name} bind:value />
+  <Toggle {id} bind:value />
 {:else if type === `placeSelect`}
-  <PlaceSelect {name} bind:value {placeholder} bnd:div />
+  <PlaceSelect {id} bind:value {placeholder} bnd:div />
 {:else if type === `singleRange`}
   <RangeSlider bind:slider float bind:values={value} {min} {max} pips all="label" />
 {:else if type === `doubleRange`}
@@ -80,21 +83,20 @@
     all="label"
   />
 {:else if type === `radio`}
-  <RadioButtons {name} bind:value {options} />
+  <RadioButtons bind:value {options} />
 {:else if type === `email`}
-  <input type="email" bind:value id={name} {name} {placeholder} />
+  <input type="email" bind:value {id} {placeholder} />
 {:else if type === `date`}
-  <input type="date" bind:value id={name} {name} {placeholder} />
+  <input type="date" bind:value {id} {placeholder} />
 {:else if type === `tel`}
-  <input type="tel" bind:value id={name} {name} {placeholder} />
+  <input type="tel" bind:value {id} {placeholder} />
 {:else if type === `text`}
-  <input type="text" bind:value id={name} {name} {placeholder} />
+  <input type="text" bind:value {id} {placeholder} />
 {:else if type === `number`}
   <input
     type="number"
     bind:value
-    id={name}
-    {name}
+    {id}
     {placeholder}
     on:wheel={(e) => type === `number` && e?.target?.blur()}
     {min}

--- a/src/components/Geocoder.svelte
+++ b/src/components/Geocoder.svelte
@@ -13,10 +13,10 @@
   export let selectHandler: (result: Result) => void
   export let placeholder = ``
   export let required = false
-  export let name: string | null = null
+  export let id: string | null = null
   export let div: HTMLDivElement
 
-  const mapboxKey = import.meta.env.VITE_MAPBOX_PUBLIC_KEY
+  const mapboxKey = import.meta.env.VITE_MAPBOX_PUBLIC_KEY as string
 
   function ignoreUpDownArrows(event: KeyboardEvent) {
     // don't move text cursor when user presses up/down arrows to choose from auto-completions
@@ -35,7 +35,7 @@
       types: `address,locality,neighborhood,poi`,
     })
 
-    geocoder.addTo(`#geocoder`)
+    geocoder.addTo(div)
 
     geocoder.on(`result`, (event: { result: Result }) => {
       geocoder.clear()
@@ -45,14 +45,7 @@
 </script>
 
 <!-- has to be <div/>, <input/> won't work -->
-<div
-  id="geocoder"
-  {name}
-  {placeholder}
-  {required}
-  bind:this={div}
-  on:keydown={ignoreUpDownArrows}
-/>
+<div {id} {placeholder} {required} bind:this={div} on:keydown={ignoreUpDownArrows} />
 
 <style>
   :global(.mapboxgl-ctrl-geocoder.mapboxgl-ctrl) {

--- a/src/components/PlaceSelect.svelte
+++ b/src/components/PlaceSelect.svelte
@@ -10,7 +10,7 @@
   export let value: Place[] = [] // currently selected places
   export let placeholder = ``
   export let div: HTMLDivElement
-  export let name: string | null = null
+  export let id: string | null = null
 
   let markers: Marker[] = []
   let map: Map
@@ -53,7 +53,7 @@
   }
 </script>
 
-<Geocoder {placeholder} {selectHandler} {name} bind:div />
+<Geocoder {placeholder} {selectHandler} {id} bind:div />
 <ol>
   {#each value ?? [] as place, idx}
     <li>

--- a/src/components/RadioButtons.svelte
+++ b/src/components/RadioButtons.svelte
@@ -1,9 +1,9 @@
-<script>
-  export let options
-  export let value = undefined
+<script lang="ts">
+  export let options: (string | number | boolean)[]
+  export let value: string | number | boolean | null = null
   export let required = false
   export let style = ``
-  export let name = ``
+  export let id: string | null = null
 </script>
 
 <div {style}>
@@ -11,8 +11,7 @@
     <label>
       <input
         type="radio"
-        id={name ? `${name}-${idx}` : undefined}
-        {name}
+        id={id ? `${id}-${idx}` : null}
         bind:group={value}
         value={option}
         {required}

--- a/src/components/Toggle.svelte
+++ b/src/components/Toggle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let name: string
+  export let id: string
   export let value = false // whether the toggle is on or off
   export let required = false
   export let input: HTMLInputElement | undefined = undefined
@@ -12,11 +12,10 @@
   }
 </script>
 
-<label for={name}>
+<label>
   <input
     type="checkbox"
-    id={name}
-    {name}
+    {id}
     bind:checked={value}
     {required}
     bind:this={input}

--- a/src/routes/signup-pupil.svelte
+++ b/src/routes/signup-pupil.svelte
@@ -26,9 +26,9 @@
     }
 
     for (const field of form.fields) {
-      if (field.name in options) {
-        field.options = options[field.name]
-      } else if (field.name === `chapter`) {
+      if (field.id in options) {
+        field.options = options[field.id]
+      } else if (field.id === `chapter`) {
         field.options = chapters.map((chap: Chapter) => chap.title)
       }
     }
@@ -50,9 +50,9 @@
     isSubmitting = true
     try {
       $signupStore.type = { value: `pupil` }
-      const fieldNames = form.fields.map((field) => field.name) // list of form fields to validate
+      const fieldIds = form.fields.map((field) => field.id) // list of form fields to validate
 
-      const response = await submitHandler(fieldNames, chapters, form.errMsg)
+      const response = await submitHandler(fieldIds, chapters, form.errMsg)
       if (response.success) success = true
       error = response.error
     } finally {

--- a/src/routes/signup-student.svelte
+++ b/src/routes/signup-student.svelte
@@ -26,9 +26,9 @@
     }
 
     for (const field of form.fields) {
-      if (field.name in options) {
-        field.options = options[field.name]
-      } else if (field.name === `chapter`) {
+      if (field.id in options) {
+        field.options = options[field.id]
+      } else if (field.id === `chapter`) {
         field.options = chapters.map((chap: Chapter) => chap.title)
       }
     }
@@ -51,9 +51,9 @@
 
     try {
       $signupStore.type = { value: `student` }
-      const fieldNames = form.fields.map((field) => field.name) // list of form fields to validate
+      const fieldIds = form.fields.map((field) => field.id) // list of form fields to validate
 
-      const response = await submitHandler(fieldNames, chapters, form.errMsg)
+      const response = await submitHandler(fieldIds, chapters, form.errMsg)
       if (response.success) success = true
       error = response.error
     } finally {

--- a/src/signup-form/de/pupil.yml
+++ b/src/signup-form/de/pupil.yml
@@ -19,33 +19,33 @@ header:
     Die Daten, die du hier eingibst, werden in [Airtable](https://airtable.com) gespeichert. Informationen zur Datenverarbeitung findest du in unserer [Datenschutzerklärung](/datenschutz).
 
 fields:
-  - name: chapter
+  - id: chapter
     title: Standort
     note: Wähle einen unserer Nachhilfestandorte.
     required: true
     type: select
     maxSelect: 1
 
-  - name: gender
+  - id: gender
     title: Geschlecht Schüler:in
     required: true
     type: select
     maxSelect: 1
 
-  - name: firstName
+  - id: firstName
     title: Vorname Schüler:in
     note: |
       Aus Datenschutzgründen bitte nicht den Nachnamen nennen. Bei mehreren Anmeldungen jeweils ein Formular ausfüllen. Wenn mehrere Schüler:innen mit gleichen Vornamen von einer Kontaktperson angemeldet werden, bitte den ersten Buchstaben vom Nachnamen hinzufügen.
     required: true
 
-  - name: subjects
+  - id: subjects
     title: Fächer
     note: |
       In welchem Fach möchtest du Nachhilfe erhalten? Für nicht aufgeführte Fächer oder sonstige Hinweise, bitte das Fach "Anderes" wählen und im Kommentarfeld unten beschreiben.
     type: select
     required: true
 
-  - name: schoolTypes
+  - id: schoolTypes
     title: Schulform
     note: |
       Auf welche Schule gehst du?
@@ -55,14 +55,14 @@ fields:
     required: true
     maxSelect: 1
 
-  - name: level
+  - id: level
     title: Klassenstufe
     required: true
     type: singleRange
     min: 1
     max: 13
 
-  - name: places
+  - id: places
     title: Wo in der Stadt?
     note: |
       Bitte gib eine oder mehrere Adressen an, in deren Nähe die Nachhilfe stattfinden kann.
@@ -72,7 +72,7 @@ fields:
     placeholder: Ort der Nachhilfe
     type: placeSelect
 
-  - name: birthYear
+  - id: birthYear
     title: Geburtsjahr Schüler:in
     required: true
     note: |
@@ -81,7 +81,7 @@ fields:
     min: 1960
     max: 2025
 
-  - name: online
+  - id: online
     title: Ist Online-Nachhilfe in Ordnung?
     note: |
       Aufgrund der Pandemie muss die Nachhilfe vielerorts zur Zeit online stattfinden ohne persönliche Treffen zwischen Schülern und Studierenden.
@@ -90,48 +90,48 @@ fields:
     type: toggle
     maxSelect: 1
 
-  - name: remarks
+  - id: remarks
     title: Bemerkungen
     note: |
       Hast du weitere Infos für uns?
 
       Hier können genauere Informationen zu Klassenstufe, Schulfächern, Förderschwerpunkte und Schultyp gegeben werden, die deine oben gewählten Antworten näher beschreiben.
 
-  - name: nameContact
+  - id: nameContact
     title: Name Kontaktperson
     note: Wie lautet der Vor- und Nachname deiner Kontaktperson (z.B. Eltern oder Sozialarbeiter:in)?
     required: true
 
-  - name: phoneContact
+  - id: phoneContact
     title: Telefon Kontaktperson
     note: Wie lautet die Telefonnummer für mögliche Rückfragen an die Kontaktperson?
     required: true
     type: tel
 
-  - name: emailContact
+  - id: emailContact
     title: E-Mail Kontaktperson
     note: |
       Wir schicken innerhalb von einer Minute eine Bestätigungs-Email an diese Adresse.
     required: true
     type: email
 
-  - name: orgContact
+  - id: orgContact
     title: Organisation Kontaktperson
     note: |
       Gehört die Kontaktperson einer Organisation an (z.B. Diakonie, Caritas, Jugendzentrum)? Bei Privatanmeldungen (z.B. durch Eltern) bitte den Namen der Schule angeben.
     required: true
 
-  - name: need
+  - id: need
     title: Finanzielle Benachteiligung
     note: Unser Angebot richtet sich speziell an Kinder und Jugendliche, für die aufgrund ihrer finanziellen Situation reguläre, kostenpflichtige Nachhilfe keine Option ist. Wir bitten um Bestätigung, dass dies auf deine Anfrage zutrifft.
     required: true
     type: toggle
 
-  - name: discovery
+  - id: discovery
     title: Werbemaßnahme
     note: Hilf uns, unsere Werbung effektiver zu gestalten, indem du uns verrätst, wie du uns gefunden hast.
 
-  - name: dataProtection
+  - id: dataProtection
     title: Einwilligung in die Datenverarbeitung
     note: |
       Informationen zur Verarbeitung deiner personenbezogenen Daten findest du unter [Vereinbarungen](/vereinbarungen#verarbeitung-personenbezogener-daten). Durch Klicken des Reglers versichere ich, dass ich diese Infos zur Kenntnis genommen habe und meine Einwilligung gebe. Mir ist bewusst, dass diese Einwilligung freiwillig erfolgt und von mir jederzeit widerrufen werden kann.

--- a/src/signup-form/de/student.yml
+++ b/src/signup-form/de/student.yml
@@ -11,74 +11,74 @@ header:
     Bitte fülle alle mit rotem Stern markierten Felder aus und klicke anschließend auf "Anmeldung abschicken".
 
 fields:
-  - name: chapter
+  - id: chapter
     title: Standort
     note: An welchem Standort möchtest du Nachhilfe geben?
     type: select
     required: true
     maxSelect: 1
 
-  - name: gender
+  - id: gender
     title: Geschlecht
     type: select
     required: true
     maxSelect: 1
 
-  - name: fullName
+  - id: fullName
     title: Vor- und Nachname
     note: Bitte so angeben, wie er im Personalausweis steht. Wird für die Ausstellung des kostenlosen Führungszeugnisses benötigt.
     required: true
 
-  - name: phone
+  - id: phone
     title: Telefon
     note: Bevorzugt eine Handynummer, damit wir dich zur Vermittlung gut erreichen können.
     type: tel
 
-  - name: email
+  - id: email
     title: E-Mail
     note: Gmx und Web.de blockieren regelmäßig unsere Emails. Am Besten gibst du eine Emailadresse von einem anderen Anbieter an.
     required: true
     type: email
 
-  - name: studySubject
+  - id: studySubject
     title: Studienfach
     note: Was studierst du?
 
-  - name: semester
+  - id: semester
     title: Semester
     note: In welchem Semester studierst du?
     type: number
     min: 1
     max: 50
 
-  - name: birthPlace
+  - id: birthPlace
     title: Geburtsort
     note: Dein Geburtsdatum und -ort brauchen wir so wie diese im Personalausweis stehen, um dir einen Antrag auf Befreiung von der Gebühr für das polizeiliche Führungszeugnis auszustellen. Da du dich bei uns ehrenamtlich engagierst, bekommst du das Zeugnis mit diesem Antrag kostenlos.
 
-  - name: birthDate
+  - id: birthDate
     title: Geburtsdatum
     note: z.B. 31.02.2001
     type: date
 
-  - name: subjects
+  - id: subjects
     title: Fächer
     note: In welchen Fächern möchtest du Nachhilfe geben? Nicht aufgeführte Fächer gerne unter Bemerkungen angeben.
     type: select
     required: true
 
-  - name: schoolTypes
+  - id: schoolTypes
     title: Schulform
     type: select
     note: Kinder von welchen Schulen möchtest du bevorzugt unterrichten?
 
-  - name: levels
+  - id: levels
     title: Klassenstufen
     note: Beispiel 5 - 8
     type: doubleRange
     min: 1
     max: 13
 
-  - name: places
+  - id: places
     title: Wo in der Stadt?
     note: |
       Bitte gib einige Adressen an, in deren Nähe du bereit wärst, Nachhilfe zu geben.
@@ -88,18 +88,18 @@ fields:
     placeholder: Ort der Nachhilfe
     type: placeSelect
 
-  - name: remarks
+  - id: remarks
     title: Bemerkungen
     note: Gibt es noch etwas, was du uns mitteilen möchtest?
 
-  - name: discovery
+  - id: discovery
     title: Werbemaßnahme
     note: Hilf uns, unsere Werbung effektiver zu gestalten, indem du uns verrätst, wie du uns gefunden hast. Wenn die passende Werbemaßnahme nicht aufgeführt ist, bitte das Zutreffendste auswählen.
     type: select
     required: true
     maxSelect: 1
 
-  - name: agreement
+  - id: agreement
     title: Vereinbarungen
     note: |
       Hiermit erkläre ich mich gemäß [der Vereinbarungen auf unserer Webseite](/vereinbarungen) mit folgenden Erklärungen einverstanden:
@@ -108,7 +108,7 @@ fields:
     required: true
     type: toggle
 
-  - name: dataProtection
+  - id: dataProtection
     title: Verarbeitung personenbezogener Daten
     note: |
       Durch Anklicken des Reglers bestätige ich, die Informationen zur Verarbeitung personenbezogener Daten unter [Vereinbarungen](/vereinbarungen) zur Kenntnis genommen zu haben und in die Datenverarbeitung zum Zwecke des Matchings mit Nachhilfeschülern einzuwilligen. Mir ist bewusst, dass diese Einwilligung freiwillig erfolgt und von mir jederzeit widerrufen werden kann.

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,10 +181,9 @@ export type CustomTypes =
   | 'radio'
 export type FormFieldType = StandardTypes | CustomTypes
 
-// used by both signup forms src/routes/anmeldung-{student,schueler}.svelte
 export type FormFieldProps = {
   title: string
-  name: keyof SignupStore
+  id: keyof SignupStore
   note?: string
   required?: boolean
   placeholder?: string

--- a/tests/pupil-form.test.ts
+++ b/tests/pupil-form.test.ts
@@ -2,10 +2,12 @@ import { expect, test } from 'vitest'
 import { fill_multi_select, fill_place_select, move_slider } from './helpers'
 import { page } from './puppeteer'
 
+const port = process.env.PORT ?? 3000
+
 test(`pupil signup form can be submitted after filling all required fields`, async () => {
   // needs the dev server running on localhost:3000 to work, fails with
   // Error: net::ERR_CONNECTION_REFUSED otherwise
-  await page.goto(`http://localhost:3000/signup-pupil`, {
+  await page.goto(`http://localhost:${port}/signup-pupil`, {
     timeout: 15_000,
     waitUntil: `networkidle2`,
   })
@@ -22,10 +24,10 @@ test(`pupil signup form can be submitted after filling all required fields`, asy
 
   await move_slider(page, `.rangeNub`)
 
-  await fill_place_select(page, `div[name='places'] input`, `Hamburg`)
+  await fill_place_select(page, `#places input`, `Hamburg`)
   await page.waitForSelector(`input[data-place='1']`)
 
-  await fill_place_select(page, `div[name='places'] input`, `Heidelberg`)
+  await fill_place_select(page, `#places input`, `Heidelberg`)
   await page.waitForSelector(`input[data-place='2']`)
 
   await page.type(`#birthYear`, `2010`)
@@ -50,7 +52,7 @@ test(`pupil signup form can be submitted after filling all required fields`, asy
 
   if (!span) throw new Error(`No success span found`)
 
-  const text = await (await span.getProperty(`textContent`)).jsonValue()
+  const text = await page.evaluate((el) => el.textContent, span)
 
   expect(text).toBe(`🎉 ⭐ 🎉`)
 })

--- a/tests/student-form.test.ts
+++ b/tests/student-form.test.ts
@@ -2,10 +2,12 @@ import { expect, test } from 'vitest'
 import { fill_multi_select, fill_place_select, move_slider } from './helpers'
 import { page } from './puppeteer'
 
+const port = process.env.PORT ?? 3000
+
 test(`student signup form can be submitted after filling all required fields`, async () => {
   // needs the dev server running on localhost:3000 to work, fails with
   // Error: net::ERR_CONNECTION_REFUSED otherwise
-  await page.goto(`http://localhost:3000/signup-student`, {
+  await page.goto(`http://localhost:${port}/signup-student`, {
     timeout: 15_000,
     waitUntil: `networkidle2`,
   })
@@ -23,10 +25,10 @@ test(`student signup form can be submitted after filling all required fields`, a
   // rangeSlider
   await move_slider(page, `.rangeNub`)
 
-  await fill_place_select(page, `div[name='places'] input`, `Hamburg`)
+  await fill_place_select(page, `#places input`, `Hamburg`)
   await page.waitForSelector(`input[data-place='1']`)
 
-  await fill_place_select(page, `div[name='places'] input`, `Heidelberg`)
+  await fill_place_select(page, `#places input`, `Heidelberg`)
   await page.waitForSelector(`input[data-place='2']`)
 
   await fill_multi_select(page, `#discovery`, [`Freunde`])
@@ -43,7 +45,7 @@ test(`student signup form can be submitted after filling all required fields`, a
 
   if (!span) throw new Error(`No success span found`)
 
-  const text = await (await span.getProperty(`textContent`)).jsonValue()
+  const text = await page.evaluate((el) => el.textContent, span)
 
   expect(text).toBe(`🎉 ⭐ 🎉`)
 })


### PR DESCRIPTION
Rationale: `id` is the attribute that associates from labels with input elements, it's more standard, and easier to use in CSS selectors. `name` is just for identifying data when receiving default HTML form submissions which we don't use anyway, instead reading form values out of a Svelte store and posting them to Airtable ourselves.