### PR TITLE
Use Airtable API to fetch dynamic landing page student + pupil counts

### DIFF
--- a/src/components/FormField.svelte
+++ b/src/components/FormField.svelte
@@ -18,7 +18,6 @@
   export let max: number | null = null
   export let maxSelect: number | null = null
 
-  let input: HTMLInputElement
   let label: HTMLLabelElement
   let slider: HTMLDivElement
 
@@ -55,7 +54,6 @@
     {options}
     {maxSelect}
     noOptionsMsg="Keine passenden Optionen"
-    bind:input
     bind:selectedLabels={value}
     --sms-options-bg="var(--accentBg)"
     --sms-bg="var(--accentBg)"

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -8,10 +8,10 @@ const prefixSlug = (prefix: string) => (obj: Page | Post) => {
   return obj
 }
 
-export async function airtableFetch(
+export async function airtableFetch<T>(
   query: string,
   options = {}
-): Promise<Record<string, unknown>> {
+): Promise<T> {
   const apiKey = import.meta.env.VITE_AIRTABLE_CHAPTER_BASE_APP_ID
 
   if (!apiKey) throw `Missing Airtable API key. Please add to .env`

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,38 +1,15 @@
 <script lang="ts" context="module">
-  import type { Load } from '@sveltejs/kit'
   import Child from '@svicons/fa-solid/child.svelte'
   import UserGraduate from '@svicons/fa-solid/user-graduate.svelte'
   import Place from '@svicons/material-sharp/place.svelte'
   import ChapterMap from '../components/ChapterMap.svelte'
   import type { Chapter, Page } from '../types'
-  import { fetchChapters, fetchPage } from '../fetch'
-
-  export const load: Load = async () => {
-    const page = await fetchPage(`/`)
-    const chapters = await fetchChapters()
-
-    // const { students, pupils } = await airtableFetch(
-    //   `{
-    //     students: studentenStatistiken {
-    //       id
-    //     }
-    //     pupils: schuelerStatistiken {
-    //       id
-    //     }
-    //   }`,
-    //   { cache: `force-cache` }
-    // )
-    return { props: { page, chapters } }
-  }
 </script>
 
 <script lang="ts">
   export let chapters: Chapter[]
   export let page: Page
-
-  let windowWidth: number
-
-  $: nImages = windowWidth > 1100 ? 7 : windowWidth < 600 ? 3 : 6
+  export let counts: { [key: string]: number }
 </script>
 
 <h1>
@@ -42,8 +19,6 @@
 <svelte:head>
   <title>Studenten bilden Schüler e.V. - Startseite</title>
 </svelte:head>
-
-<svelte:window bind:innerWidth={windowWidth} />
 
 <h2>
   Kostenlose Nachhilfe von ehrenamtlichen Studierenden für finanziell benachteiligte
@@ -56,11 +31,11 @@
     <Place height="2.5ex" style="vertical-align: middle;" />Standorte
   </div>
   <div style="background: var(--green);">
-    <span>2872</span>
+    <span>{counts.students}</span>
     <UserGraduate height="2.5ex" style="vertical-align: middle;" />Studierende
   </div>
   <div style="background: var(--orange);">
-    <span>3186</span>
+    <span>{counts.pupils}</span>
     <Child height="2.5ex" style="vertical-align: middle;" />Schüler:innen
   </div>
   <div style="background: var(--lightBlue);">

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from '@sveltejs/kit'
+import { airtableFetch, fetchChapters, fetchPage } from '../fetch'
+
+export const get: RequestHandler = async () => {
+  const page = await fetchPage(`/`)
+  const chapters = await fetchChapters()
+
+  const { students, pupils } = await airtableFetch<{
+    students: number[]
+    pupils: number[]
+  }>(
+    `{
+          students: studentenStatistiken {
+            id
+          }
+          pupils: schuelerStatistiken {
+            id
+          }
+        }`,
+    { cache: `force-cache` }
+  )
+
+  return {
+    body: {
+      page,
+      chapters,
+      counts: { students: students.length, pupils: pupils.length },
+    },
+  }
+}

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -15,23 +15,23 @@ colorMode.subscribe(
     hasLocalStore && (localStorage[colorModeKey] = val)
 )
 
-function createSessionStore<T>(name: string, defaultValue: T) {
-  const store = writable<T>(
-    hasSessionStore && sessionStorage[name]
-      ? JSON.parse(sessionStorage[name])
-      : defaultValue
-  )
-
-  if (hasSessionStore) {
-    store.subscribe(
-      (val: unknown) => (sessionStorage[name] = JSON.stringify(val))
-    )
+function sessionStore<T>(name: string, initialValue: T) {
+  if (hasSessionStore && localStorage[name]) {
+    initialValue = JSON.parse(localStorage[name])
   }
 
-  return store
+  const { subscribe, set } = writable(initialValue)
+
+  return {
+    subscribe,
+    set: (val: T) => {
+      if (hasSessionStore) localStorage[name] = JSON.stringify(val)
+      set(val)
+    },
+  }
 }
 
-export const signupStore = createSessionStore<SignupStore>(
+export const signupStore = sessionStore<SignupStore>(
   `SignupStore`,
   {} as SignupStore
 )


### PR DESCRIPTION
Current implementation is super slow. I think that's due to a mixture of using 3rd party GraphQL API + needlessly fetching all table ids rather than getting just the table row count directly, i.e. fetching just one number for student and pupil table each rather than the current ~6.5k row ids.

@kleinicke @l8l @GG8000 Could we try [this suggestion](https://community.airtable.com/t/get-the-number-of-records-in-a-table-via-api/45168/13) of having a derived table that counts entries in our student and pupil tables?