### PR TITLE
Fix student signup form error 'Unknown field name: Kontaktpersonen'

### DIFF
--- a/src/routes/signup-student.svelte
+++ b/src/routes/signup-student.svelte
@@ -50,9 +50,13 @@
 
     try {
       $signupStore.type = { value: `student` }
-      const fieldIds = form.fields.map((field) => field.id) // list of form fields to validate
+      const field_ids_to_validate = form.fields.map((field) => field.id) // list of form fields to validate
 
-      const response = await signup_form_submit_handler(fieldIds, chapters, form.errMsg)
+      const response = await signup_form_submit_handler(
+        field_ids_to_validate,
+        chapters,
+        form.errMsg
+      )
       if (response.success) success = true
       error = response.error
     } finally {

--- a/src/signup-form/de/student.yml
+++ b/src/signup-form/de/student.yml
@@ -36,7 +36,7 @@ fields:
 
   - id: email
     title: E-Mail
-    note: Gmx und Web.de blockieren regelmäßig unsere Emails. Am Besten gibst du eine Emailadresse von einem anderen Anbieter an.
+    note: Gmx und Web.de blockieren regelmäßig die Zustellung unserer Emails. Wenn möglich, gib uns bitte deine Mailadresse eines anderen Anbieters.
     required: true
     type: email
 

--- a/src/utils/airtable.ts
+++ b/src/utils/airtable.ts
@@ -98,19 +98,17 @@ export async function prepare_signup_data_for_airtable(
     Spur: window.visitedPages.join(`,\n`),
   }
 
-  const chapterFields = { ...fields, Kontaktpersonen: data.nameContact?.value }
-
   const globalBaseId = `appSswal9DNdJKRB8` // global base called 'Alle Standorte' in Airtable
   const testBaseId = `appe3hVONuwBkuQv1` // called 'Anmeldeformular Test Base' in Airtable
 
   if (test) {
-    console.log(`chapterFields:`, chapterFields) // eslint-disable-line no-console
-    return await airtable_post_new_records(testBaseId, table, chapterFields)
+    console.log(`fields:`, fields) // eslint-disable-line no-console
+    return await airtable_post_new_records(testBaseId, table, fields)
   }
   // use Promise.all() to fail fast if one record creation fails
   return await Promise.all([
     airtable_post_new_records(globalBaseId, table, globalFields),
-    airtable_post_new_records(chapterBaseId, table, chapterFields),
+    airtable_post_new_records(chapterBaseId, table, fields),
   ])
 }
 


### PR DESCRIPTION
This was reported by Deggendorf studenten.deggendorf@studenten-bilden-schueler.de but potentially affected multiple chapters.

One potential pitfall here: I'm wondering why this insertion was left there in the first place. @kleinicke @GG8000 @l8l Do some chapter bases contain differently named columns, i.e. Kontaktperson vs Kontaktpersonen?

If so, merging this PR would cause new errors. We should first unify column names, then merge.