### PR TITLE
Fix low-contrast issue for partner SVG logos in dark theme

### DIFF
--- a/static/dark-theme.css
+++ b/static/dark-theme.css
@@ -14,3 +14,37 @@
   --invert: 1;
   --transparent: rgba(0, 0, 0, 0.5);
 }
+
+h2#-a-href-mitmachen-kooperationspartner-wir-werden-unterstützt-durch-a-
+  + section
+  img {
+  filter: drop-shadow(1px 0 white) drop-shadow(-1px 0 white)
+    drop-shadow(0 1px white) drop-shadow(0 -1px white);
+}
+
+/* Alternatives to increase contrast of images */
+/* h2#-a-href-mitmachen-kooperationspartner-wir-werden-unterstützt-durch-a- + section img {
+    background: radial-gradient(
+      circle,
+      var(--light-blue) 0%,
+      transparent 100%
+    );
+    } */
+
+/* h2#-a-href-mitmachen-kooperationspartner-wir-werden-unterstützt-durch-a- + section {
+    position: relative;
+    overflow: hidden;
+  }
+
+  h2#-a-href-mitmachen-kooperationspartner-wir-werden-unterstützt-durch-a- + section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle, var(--blue) 60%, transparent 100%);
+    z-index: 0;
+  }
+
+  h2#-a-href-mitmachen-kooperationspartner-wir-werden-unterstützt-durch-a- + section * {
+    position: relative;
+    z-index: 1;
+  } */


### PR DESCRIPTION
## Description

This PR addresses Issue #138 about the low contrast of the partners section on the main page where SVG icons were difficult to see against the dark theme background. The solution applies a 1pt drop shadow in white for every direction to the .svg. This increases contrast without altering the logo colors themselves, ensuring better accessibility and readability in dark mode.

However, the implementation via CSS selectors is not robust or clean. It would be much nice to do it via contentful (But I don't have access to the system, therefore this PR is serving just as a suggestion)

## Changelog

#### Added

- CSS rule targeting images in the section immediately following the h2 with ID `-a-href-mitmachen-kooperationspartner-wir-werden-unterstützt-durch-a-` 
  - applies stacked white drop-shadow filters in four directions around partner SVG logos to create a sharp outline

## Additional information

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/041d1368-dabb-4179-a371-54ae43b91e7a" width="300"/> | <img src="https://github.com/user-attachments/assets/0a91d829-17e1-451c-a98c-2cb9418d44c9" width="300"/> |